### PR TITLE
Updating/adding copilot-setup-steps.yaml to enable the Copilot coding agent to access Azure

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: copilot
+    steps:
+      - name: Install azd
+        uses: Azure/setup-azd@v2
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
Update copilot-setup-steps.yml to use a federated credential to access Azure resources.

## Final steps

**NOTE: one final step, and you're ready to use the Copilot coding agent with Azure!**

After this pull request merges, you'll need to update the Copilot coding agent's MCP settings [(link)](https://github.com/ahmedbham/VIBE-AGENT-FRAMEWORK-WORKFLOW/settings/copilot/coding_agent#:~:text=JSON%20MCP%20configuration-,MCP%20configuration,-1) with
the following JSON to activate the Azure MCP server:

```json
{
    "mcpServers": {
        "Azure": {
            "type": "local",
            "command": "npx",
            "args": [
                "-y",
                "@azure/mcp@latest",
                "server",
                "start"
            ],
            "tools": [
                "*"
            ]
        }
    }
}

```

## Extending the managed identity's roles and scopes

By default, the identity is configured with the Reader role, on the resource group you created/selected. You can expand the role and scope for the identity, to fit better with your needs:

Some further instructions on how to assign roles:

- [Using the Azure portal to assign roles](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-portal-managed-identity)
- [Using the Azure CLI to assign roles](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli)
- [Azure built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles)

## Resources

- `coding-agent` readme: ([link](https://github.com/Azure/azure-dev/blob/main/cli/azd/extensions/azure.coding-agent/README.md#troubleshooting))
